### PR TITLE
Change extension ID to `java-jdtls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "java-support"
+name = "java-jdtls"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/extension.toml
+++ b/extension.toml
@@ -1,4 +1,4 @@
-id = "java-support"
+id = "java-jdtls"
 name = "Java with Eclipse JDTLS"
 version = "0.0.1"
 schema_version = 1


### PR DESCRIPTION
The current ID `java-support` is inconsistent with other language support extensions and does not adequately differentiate between the existing `java` extension. I think `java-jdtls` works better since it's a bit more consistent and it allows a user to easily tell the difference between this extension and the `java` extension, the main difference being that this extension has a language server, jdtls.