### PR TITLE
Change initial extension version to v0.1.0

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "java-support"
 name = "Java with Eclipse JDTLS"
-version = "0.0.1"
+version = "0.1.0"
 schema_version = 1
 authors = ["Yury Abykhodau <abehodau@gmail.com>", "Valentine Briese <valentinegb@icloud.com>"]
 description = "☕️ Java language support for Zed with Eclipse JDTLS"


### PR DESCRIPTION
The current extension version, v0.0.1, is inconsistent with the initial version in `Cargo.toml`, which is v0.1.0. Also, the first version probably shouldn't be considered a bug fix update in terms of semantic versioning.