### PR TITLE
Fix filter range for method completion label

### DIFF
--- a/src/java.rs
+++ b/src/java.rs
@@ -117,8 +117,7 @@ impl Extension for JavaExtension {
 
                 Some(CodeLabel {
                     spans: vec![CodeLabelSpan::code_range(0..code.len())],
-                    filter_range: (return_type.len() + 1..return_type.len() + 1 + name.len())
-                        .into(),
+                    filter_range: (0..name.len()).into(),
                     code,
                 })
             }


### PR DESCRIPTION
The changes made to method completion labels in 39175e5 broke the ability to search for methods because the filter range was not updated, which was configured for the previous arrangement of the label. This PR rearranges the filter range to match the new label.

Also, personally, I prefer the previous label because it kept with the trend in other languages in Zed of making the label appear similar to how the code is written, but I consider myself a Rust dev first and foremost so it's not really my place to decide what's preferable for Java developers.