### PR TITLE
Add support for `initialization_options`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 name = "java-jdtls"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "zed_extension_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ path = "src/java.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+serde_json = "1.0.116"
 zed_extension_api = "0.0.6"

--- a/src/java.rs
+++ b/src/java.rs
@@ -3,9 +3,10 @@ use std::fs;
 use zed_extension_api::{
     current_platform, download_file, latest_github_release,
     lsp::{Completion, CompletionKind},
-    make_file_executable, register_extension, set_language_server_installation_status, CodeLabel,
-    CodeLabelSpan, DownloadedFileType, Extension, GithubReleaseOptions, LanguageServerId,
-    LanguageServerInstallationStatus, Os, Result, Worktree,
+    make_file_executable, register_extension, set_language_server_installation_status,
+    settings::LspSettings,
+    CodeLabel, CodeLabelSpan, DownloadedFileType, Extension, GithubReleaseOptions,
+    LanguageServerId, LanguageServerInstallationStatus, Os, Result, Worktree,
 };
 
 struct JavaExtension {
@@ -102,6 +103,18 @@ impl Extension for JavaExtension {
             args: Vec::new(),
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        // jdtls only accepts settings via. workspace/didChangeConfiguration, not
+        // initialization options, so pass the user's initialization options to
+        // workspace/didChangeConfiguration as well.
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
+        Ok(settings.initialization_options)
     }
 
     fn label_for_completion(


### PR DESCRIPTION
With this change, you can do the equivalent of setting `"java.foo.bar": true` with https://github.com/redhat-developer/vscode-java by putting this in your `settings.json`:

```jsonc
{
  "lsp": {
    "java": {
      "initialization_options": {
        "java": {
          "foo": {
            "bar": true
          }
        }
        // also works
        // "java.foo.bar": true
      }
    }
  }
}
```